### PR TITLE
Run vector tests on self-hosted runners

### DIFF
--- a/.github/workflows/run-frequent.yaml
+++ b/.github/workflows/run-frequent.yaml
@@ -37,10 +37,30 @@ jobs:
         mode: [newlib, linux]
         target:
           [
-            rv32gcv-ilp32d, # rv32 vector
-            rv64gcv-lp64d, # rv64 vector
             rv32gc_zba_zbb_zbc_zbs-ilp32d, # rv32 bitmanip
             rv64gc_zba_zbb_zbc_zbs-lp64d, # rv64 bitmanip
+          ]
+        multilib: [non-multilib]
+    uses: ./.github/workflows/build-test.yaml
+    with:
+      mode: ${{ matrix.mode }}
+      target: ${{ matrix.target }}
+      gcchash: ${{ needs.init-submodules.outputs.gcchash }}
+      multilib: ${{ matrix.multilib }}
+      multitarget: ${{ github.event.inputs.multi_target }}
+      riscv_gnu_toolchain_hash: ${{ needs.init-submodules.outputs.riscv_gnu_toolchain_hash }}
+      run_on_self_hosted: false
+
+  creg-sh: # Check Regressions Self Hosted. Short name so I can see the matrix string in github
+    needs: [init-submodules]
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [newlib, linux]
+        target:
+          [
+            rv32gcv-ilp32d, # rv32 vector
+            rv64gcv-lp64d, # rv64 vector
             rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d, # rv32 vector crypto
             rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d, # rv64 vector crypto
             rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d, # RVA23U64 profile with optional extensions, excluding unsupported extensions
@@ -54,7 +74,7 @@ jobs:
       multilib: ${{ matrix.multilib }}
       multitarget: ${{ github.event.inputs.multi_target }}
       riscv_gnu_toolchain_hash: ${{ needs.init-submodules.outputs.riscv_gnu_toolchain_hash }}
-      run_on_self_hosted: false
+      run_on_self_hosted: true
 
   cmreg: # Check Multilib Regressions. Short name so I can see the matrix string in github
     needs: [init-submodules]


### PR DESCRIPTION
Ever since additional vector tests were enabled, vector targets consistently time out on github runners.
First seen: https://github.com/gcc-mirror/gcc/compare/3bfde22cbfa689a4c09f5727fb6f693241ce1d6a...3da32cc3d1e48f2eac1630e627d34723b9536166
This PR moves those runs to our self-hosted runner(s). If our self-hosted runner(s) get overwhelmed we may need to reevaluate this and come up with alternative strategies.

A similar change is likely needed for pre-commit ci.