### PR TITLE
Use self-hosted runners for rvv-intrinsics check

### DIFF
--- a/.github/workflows/rvv-intrinsic-test.yaml
+++ b/.github/workflows/rvv-intrinsic-test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   rvv-intrinsic-testing:
-    runs-on: ubuntu-20.04
+    runs-on: self-hosted
     environment: production
     steps:
       - uses: actions/checkout@v3
@@ -62,7 +62,7 @@ jobs:
       - name: Check gcc result
         run: |
           tail -n 17 riscv-gnu-toolchain/build-gcc-newlib-stage2/gcc/testsuite/gcc/gcc.log
-  
+
       - name: Check g++ result
         run: |
           tail -n 27 riscv-gnu-toolchain/build-gcc-newlib-stage2/gcc/testsuite/g++/g++.log


### PR DESCRIPTION
Currently the rvv-intrinsics check seems to fail with an [out of memory issue](https://github.com/patrick-rivos/gcc-postcommit-ci/actions/runs/6676402497/job/18145599057)? The self hosted runners have way more RAM, so let's try running it there.