### PR TITLE
Hardcode threads to avoid timeouts with large numbers of runners

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -59,7 +59,7 @@ runs:
         run: |
           cd build
           set -o pipefail
-          (make -j $(nproc) ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
+          (make -j20 ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
           set +o pipefail
 
       - name: Zip build log

--- a/.github/actions/common/run-testsuite/action.yaml
+++ b/.github/actions/common/run-testsuite/action.yaml
@@ -22,7 +22,7 @@ runs:
         working-directory: riscv-gnu-toolchain
         run: |
           cd build
-          make -j $(nproc) report-${{ inputs.mode }} || true
+          make -j20 report-${{ inputs.mode }} || true
 
       - name: Build debug log zip
         shell: bash

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -227,7 +227,7 @@ jobs:
       - name: Build
         run: |
           cd build
-          make ${{ inputs.mode }} -j $(nproc)
+          make ${{ inputs.mode }} -j20
 
       - name: Run Testsuite
         uses: ./.github/actions/common/run-testsuite


### PR DESCRIPTION
This should be helpful for large runners like the rise runner so we can add more without encountering timeouts.