### PR TITLE
Revert "add zfa extension to bitmanip"

### DIFF
--- a/.github/actions/common/restore-stage-2/action.yaml
+++ b/.github/actions/common/restore-stage-2/action.yaml
@@ -48,13 +48,13 @@ runs:
           touch -d "+2 days" build-glibc-linux-rv32imac-ilp32
           touch -d "+2 days" build-glibc-linux-rv32imafdc-ilp32d
           touch -d "+2 days" build-glibc-linux-rv32gcv-ilp32d
-          touch -d "+2 days" build-glibc-linux-rv32gc_zba_zbb_zbc_zbs_zfa-ilp32d
+          touch -d "+2 days" build-glibc-linux-rv32gc_zba_zbb_zbc_zbs-ilp32d
           touch -d "+2 days" build-glibc-linux-rv32gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-ilp32d
           touch -d "+2 days" build-glibc-linux-rv64gc-lp64d
           touch -d "+2 days" build-glibc-linux-rv64imac-lp64
           touch -d "+2 days" build-glibc-linux-rv64imafdc-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gcv-lp64d
-          touch -d "+2 days" build-glibc-linux-rv64gc_zba_zbb_zbc_zbs_zfa-lp64d
+          touch -d "+2 days" build-glibc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d
           touch -d "+2 days" build-glibc-linux-rv64gcv_zvbb_zvbc_zvkg_zvkn_zvknc_zvkned_zvkng_zvknha_zvknhb_zvks_zvksc_zvksed_zvksg_zvksh_zvkt-lp64d
           touch -d "+2 days" build-glibc-linux-rv64imafdcv_zicond_zawrs_zbc_zvkng_zvksg_zvbb_zvbc_zicsr_zba_zbb_zbs_zicbom_zicbop_zicboz_zfhmin_zkt-lp64d
           touch -d "+2 days" build-newlib-nano

--- a/.github/actions/download-all-comparison-artifacts/action.yaml
+++ b/.github/actions/download-all-comparison-artifacts/action.yaml
@@ -28,15 +28,15 @@ runs:
     - name: Download linux rv32 bitmanip non-multilib
       uses: ./.github/actions/common/download-comparison-artifacts
       with:
-        report-artifact-name: gcc-linux-rv32gc_zba_zbb_zbc_zbs_zfa-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
-        binary-artifact-name: gcc-linux-rv32gc_zba_zbb_zbc_zbs_zfa-ilp32d-${{ inputs.gcchash }}-non-multilib
+        report-artifact-name: gcc-linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+        binary-artifact-name: gcc-linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib
         github-token: ${{ inputs.token }}
 
     - name: Download linux rv64 bitmanip non-multilib
       uses: ./.github/actions/common/download-comparison-artifacts
       with:
-        report-artifact-name: gcc-linux-rv64gc_zba_zbb_zbc_zbs_zfa-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
-        binary-artifact-name: gcc-linux-rv64gc_zba_zbb_zbc_zbs_zfa-lp64d-${{ inputs.gcchash }}-non-multilib
+        report-artifact-name: gcc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+        binary-artifact-name: gcc-linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib
         github-token: ${{ inputs.token }}
 
     # Newlib
@@ -58,14 +58,15 @@ runs:
     - name: Download newlib rv32 bitmanip non-multilib
       uses: ./.github/actions/common/download-comparison-artifacts
       with:
-        report-artifact-name: gcc-newlib-rv32gc_zba_zbb_zbc_zbs_zfa-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
-        binary-artifact-name: gcc-newlib-rv32gc_zba_zbb_zbc_zbs_zfa-ilp32d-${{ inputs.gcchash }}-non-multilib
+        report-artifact-name: gcc-newlib-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-report.log
+        binary-artifact-name: gcc-newlib-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib
         github-token: ${{ inputs.token }}
 
+    - name: Download newlib rv64 bitmanip non-multilib
       uses: ./.github/actions/common/download-comparison-artifacts
       with:
-        report-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs_zfa-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
-        binary-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs_zfa-lp64d-${{ inputs.gcchash }}-non-multilib
+        report-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-report.log
+        binary-artifact-name: gcc-newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib
         github-token: ${{ inputs.token }}
 
     # Multilib

--- a/.github/workflows/run-frequent.yaml
+++ b/.github/workflows/run-frequent.yaml
@@ -39,8 +39,8 @@ jobs:
           [
             rv32gc-ilp32d,
             rv64gc-lp64d,
-            rv32gc_zba_zbb_zbc_zbs_zfa-ilp32d, # rv32 bitmanip
-            rv64gc_zba_zbb_zbc_zbs_zfa-lp64d, # rv64 bitmanip
+            rv32gc_zba_zbb_zbc_zbs-ilp32d, # rv32 bitmanip
+            rv64gc_zba_zbb_zbc_zbs-lp64d, # rv64 bitmanip
           ]
         multilib: [non-multilib]
     uses: ./.github/workflows/build-test.yaml

--- a/.github/workflows/run-weekly.yaml
+++ b/.github/workflows/run-weekly.yaml
@@ -29,8 +29,8 @@ jobs:
           rv64gc-lp64d,
           rv32gcv-ilp32d, # rv32 vector
           rv64gcv-lp64d, # rv64 vector
-          rv32gc_zba_zbb_zbc_zbs_zfa-ilp32d, # rv32 bitmanip
-          rv64gc_zba_zbb_zbc_zbs_zfa-lp64d, # rv64 bitmanip
+          rv32gc_zba_zbb_zbc_zbs-ilp32d, # rv32 bitmanip
+          rv64gc_zba_zbb_zbc_zbs-lp64d, # rv64 bitmanip
         ]
     uses: ./.github/workflows/build-with-checking.yaml
     with:


### PR DESCRIPTION
Reverts patrick-rivos/gcc-postcommit-ci#359. Double checking to make sure zfa is supported by QEMU before it gets consumed