### PR TITLE
Split uc targets into rv64/rv32 to reduce latency

### DIFF
--- a/.github/actions/download-all-comparison-artifacts/action.yaml
+++ b/.github/actions/download-all-comparison-artifacts/action.yaml
@@ -89,8 +89,22 @@ runs:
     - name: Download newlib uc multilib
       uses: ./.github/actions/common/download-comparison-artifacts
       with:
+        report-artifact-name: ${{ inputs.prefix }}gcc-newlib-rv32imc-lp32d-${{ inputs.gcchash }}-multilib-report.log
+        binary-artifact-name: ${{ inputs.prefix }}gcc-newlib-rv32imc-lp32d-${{ inputs.gcchash }}-multilib
+        github-token: ${{ inputs.token }}
+
+    - name: Download newlib uc multilib
+      uses: ./.github/actions/common/download-comparison-artifacts
+      with:
         report-artifact-name: ${{ inputs.prefix }}gcc-newlib-rv64imc-lp64d-${{ inputs.gcchash }}-multilib-report.log
         binary-artifact-name: ${{ inputs.prefix }}gcc-newlib-rv64imc-lp64d-${{ inputs.gcchash }}-multilib
+        github-token: ${{ inputs.token }}
+
+    - name: Download newlib uc bitmanip multilib
+      uses: ./.github/actions/common/download-comparison-artifacts
+      with:
+        report-artifact-name: ${{ inputs.prefix }}gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-multilib-report.log
+        binary-artifact-name: ${{ inputs.prefix }}gcc-newlib-rv32imc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-multilib
         github-token: ${{ inputs.token }}
 
     - name: Download newlib uc bitmanip multilib

--- a/.github/workflows/run-frequent.yaml
+++ b/.github/workflows/run-frequent.yaml
@@ -77,18 +77,20 @@ jobs:
       multitarget: ${{ github.event.inputs.multi_target }}
       run_on_self_hosted: true
       prefix: ''
-     
+
   cmreg-self-hosted-uc: # Check Multilib Regressions. Short name so I can see the matrix string in github
     needs: [init-submodules]
     strategy:
       fail-fast: false
       matrix:
         mode: [newlib] # linux does not support no a extension
-        target: 
+        target:
           [
             # Left as rv64 with lp64d instead of lp64 for naming
-            rv64imc-lp64d, # runs base targets 
+            rv64imc-lp64d, # runs base targets
             rv64imc_zba_zbb_zbc_zbs-lp64d, # runs base + bitmanip
+            rv32imc-ilp32d, # runs base targets
+            rv32imc_zba_zbb_zbc_zbs-ilp32d, # runs base + bitmanip
           ]
         multilib: [multilib]
     uses: ./.github/workflows/build-test.yaml

--- a/configure-scripts/rv32imc-ilp32d
+++ b/configure-scripts/rv32imc-ilp32d
@@ -1,0 +1,3 @@
+#!/bin/bash
+../configure --prefix=$(pwd) --with-multilib-generator="rv32imac-ilp32--;rv32imc-ilp32--;rv32imc_zicsr_zifencei-ilp32--"
+

--- a/configure-scripts/rv32imc_zba_zbb_zbc_zbs-ilp32d
+++ b/configure-scripts/rv32imc_zba_zbb_zbc_zbs-ilp32d
@@ -1,0 +1,3 @@
+#!/bin/bash
+../configure --prefix=$(pwd) --with-multilib-generator="rv32imac_zba_zbb_zbc-ilp32--;rv32imc_zba_zbb_zbc-ilp32--;rv32imc_zba_zbb_zbc_zicsr_zifencei-ilp32--;rv32imc_zba_zbb_zbc_zbs_zicsr_zifencei-ilp32--"
+

--- a/configure-scripts/rv64imc-lp64d
+++ b/configure-scripts/rv64imc-lp64d
@@ -1,3 +1,3 @@
 #!/bin/bash
-../configure --prefix=$(pwd) --with-multilib-generator="rv32imac-ilp32--;rv64imac-lp64--;rv32imc-ilp32--;rv64imc-lp64--;rv32imc_zicsr_zifencei-ilp32--;rv64imc_zicsr_zifencei-lp64--"
+../configure --prefix=$(pwd) --with-multilib-generator="rv64imac-lp64--;rv64imc-lp64--;rv64imc_zicsr_zifencei-lp64--"
 

--- a/configure-scripts/rv64imc_zba_zbb_zbc_zbs-lp64d
+++ b/configure-scripts/rv64imc_zba_zbb_zbc_zbs-lp64d
@@ -1,3 +1,3 @@
 #!/bin/bash
-../configure --prefix=$(pwd) --with-multilib-generator="rv32imac_zba_zbb_zbc-ilp32--;rv64imac_zba_zbb_zbc-lp64--;rv32imc_zba_zbb_zbc-ilp32--;rv64imc_zba_zbb_zbc-lp64--;rv32imc_zba_zbb_zbc_zicsr_zifencei-ilp32--;rv64imc_zba_zbb_zbc_zicsr_zifencei-lp64--;rv32imc_zba_zbb_zbc_zbs-ilp32--;rv64imc_zba_zbb_zbc_zbs-lp64--;rv32imc_zba_zbb_zbc_zbs_zicsr_zifencei-ilp32--;rv64imc_zba_zbb_zbc_zbs_zicsr_zifencei-lp64--"
+../configure --prefix=$(pwd) --with-multilib-generator="rv64imac_zba_zbb_zbc-lp64--;rv64imc_zba_zbb_zbc-lp64--;rv64imc_zba_zbb_zbc_zicsr_zifencei-lp64--;rv64imc_zba_zbb_zbc_zbs_zicsr_zifencei-lp64--"
 


### PR DESCRIPTION
Currently UC targets have a 7.5+ hr latency. This is up from gcv which has a 2.5 hr latency. This causes downstream problems with precommit