### PR TITLE
Install zip and unzip when running

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -40,6 +40,8 @@ runs:
           sudo ./.github/setup-apt.sh
           sudo apt install python3 -y
           sudo apt install python-is-python3 -y
+          sudo apt install zip -y
+          sudo apt install unzip -y
 
       - name: Configure
         shell: bash


### PR DESCRIPTION
Allows us to install the self-hosted runners without manually installing zip/unzip