### PR TITLE
Bump actions to Node.js 20 versions

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -70,7 +70,7 @@ runs:
 
       - name: Upload build log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.build_log_name }}
           path: |
@@ -84,7 +84,7 @@ runs:
           zip -r ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}.zip build/bin
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}
           path: |
@@ -101,7 +101,7 @@ runs:
 
       - name: Upload stage2 artifact
         if: ${{ inputs.upload_stage2_artifacts == 'true' }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-stage2
           path: |

--- a/.github/actions/common/download-comparison-artifacts/action.yaml
+++ b/.github/actions/common/download-comparison-artifacts/action.yaml
@@ -14,7 +14,7 @@ runs:
     - name: Download report from this workflow
       if: ${{ !cancelled() }}
       id: same-workflow-report
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.report-artifact-name }}
         path: ./riscv-gnu-toolchain/current_logs
@@ -43,7 +43,7 @@ runs:
     - name: Download binary artifact from this workflow
       if: ${{ !cancelled() && steps.report-download.outputs.report_download == 'failure'}}
       id: same-workflow-binary
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: ${{ inputs.binary-artifact-name }}
         path: ./riscv-gnu-toolchain/temp

--- a/.github/actions/common/restore-stage-2/action.yaml
+++ b/.github/actions/common/restore-stage-2/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
       - name: Restore stage2
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-stage2
           path: ./riscv-gnu-toolchain

--- a/.github/actions/common/run-testsuite/action.yaml
+++ b/.github/actions/common/run-testsuite/action.yaml
@@ -40,7 +40,7 @@ runs:
           zip -r ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-debug-output.zip ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-debug-output.log
 
       - name: Upload debug artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-debug-output.log
           path: |
@@ -60,7 +60,7 @@ runs:
           zip -r ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-sum-files.zip sum_files
 
       - name: Upload sum file artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-sum-files
           path: |
@@ -79,7 +79,7 @@ runs:
           $PARSE_EXISTING_REPORT | tee ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-report.log || true
 
       - name: Upload results artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-report.log
           path: |

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -52,7 +52,7 @@ jobs:
     needs: [check]
     if: ${{ needs.check.outputs.early_exit != 'exit' && inputs.run_on_self_hosted != 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -60,7 +60,7 @@ jobs:
           free_up_space: true
 
       - name: Restore submodules from cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-sources-${{ inputs.gcchash }}
           path: riscv-gnu-toolchain
@@ -109,7 +109,7 @@ jobs:
     # Skip linux multilib
     if: ${{ needs.check.outputs.early_exit != 'exit' && inputs.run_on_self_hosted != 'true' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -117,7 +117,7 @@ jobs:
           free_up_space: true
 
       - name: Restore submodules from cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-sources-${{ inputs.gcchash }}
           path: riscv-gnu-toolchain
@@ -184,7 +184,7 @@ jobs:
           rm -rf ./.??* || true
           ls -la ./
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -192,7 +192,7 @@ jobs:
           free_up_space: false
 
       - name: Restore submodules from cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-sources-${{ inputs.gcchash }}
           path: riscv-gnu-toolchain
@@ -258,7 +258,7 @@ jobs:
           rm -rf ./.??* || true
           ls -la ./
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -266,7 +266,7 @@ jobs:
           free_up_space: false
 
       - name: Restore submodules from cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-sources-${{ inputs.gcchash }}
           path: riscv-gnu-toolchain

--- a/.github/workflows/build-with-checking.yaml
+++ b/.github/workflows/build-with-checking.yaml
@@ -44,7 +44,7 @@ jobs:
     needs: [check]
     if: ${{ needs.check.outputs.early_exit != 'exit' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -52,7 +52,7 @@ jobs:
           free_up_space: true
 
       - name: Restore submodules from cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gcc-sources-${{ inputs.gcchash }}
           path: riscv-gnu-toolchain
@@ -92,7 +92,7 @@ jobs:
           zip -r gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-rtl-checking.zip build/bin
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gcc-${{ inputs.mode }}-${{ inputs.target }}-${{ inputs.gcchash }}-${{ inputs.multilib }}-rtl-checking
           path: |

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -87,4 +87,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-dashboard.yaml
+++ b/.github/workflows/deploy-dashboard.yaml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -114,7 +114,7 @@ jobs:
       run:
         working-directory: riscv-gnu-toolchain
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -123,7 +123,7 @@ jobs:
 
       - name: Retrieve cache
         id: retrieve-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             riscv-gnu-toolchain/.git
@@ -241,7 +241,7 @@ jobs:
           zip -r previous_logs.zip previous_logs
 
       - name: Upload compare summaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.gcchash }}-summaries
           path: |
@@ -249,7 +249,7 @@ jobs:
           retention-days: 90
 
       - name: Upload current log failures
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.gcchash }}-current-logs
           path: |
@@ -257,7 +257,7 @@ jobs:
           retention-days: 90
 
       - name: Upload previous log failures
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.gcchash }}-previous-logs
           path: |
@@ -274,7 +274,7 @@ jobs:
       run:
         working-directory: riscv-gnu-toolchain
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -282,19 +282,19 @@ jobs:
           free_up_space: false
 
       - name: Download summaries artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.gcchash }}-summaries
           path: ./riscv-gnu-toolchain
 
       - name: Download current logs artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.gcchash }}-current-logs
           path: ./riscv-gnu-toolchain
 
       - name: Download previous logs artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.gcchash }}-previous-logs
           path: ./riscv-gnu-toolchain
@@ -349,7 +349,7 @@ jobs:
           cat trimmed_issue.md
 
       - name: Create or update summary issue
-        uses: peter-evans/create-issue-from-file@v4
+        uses: peter-evans/create-issue-from-file@v5
         id: create-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -481,7 +481,7 @@ jobs:
               body: 'Bisecting with #${{ needs.generate-issues.outputs.new_issue_num }}'
             })
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -497,7 +497,7 @@ jobs:
 
       - name: Retrieve cache
         id: retrieve-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             riscv-gnu-toolchain/.git
@@ -619,7 +619,7 @@ jobs:
           zip -r previous_logs.zip previous_logs
 
       - name: Upload compare summaries
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ steps.bisection-hash.outputs.orig_gcchash }}-regenerated-summaries
           path: |
@@ -627,7 +627,7 @@ jobs:
           retention-days: 90
 
       - name: Upload current log failures
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ steps.bisection-hash.outputs.orig_gcchash }}-regenerated-current-logs
           path: |
@@ -635,7 +635,7 @@ jobs:
           retention-days: 90
 
       - name: Upload previous log failures
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ steps.bisection-hash.outputs.orig_gcchash }}-regenerated-previous-logs
           path: |

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -384,7 +384,7 @@ jobs:
           echo "label=$LABEL" >> $GITHUB_OUTPUT
 
       - name: Add Prefix Label to New Issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ inputs.prefix != '' }}
         with:
           script: |
@@ -396,7 +396,7 @@ jobs:
             })
 
       - name: Add Staging Label to New Issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         if: ${{ github.workflow == 'Staging' }}
         with:
           script: |
@@ -449,7 +449,7 @@ jobs:
     if: ${{ inputs.issue_num != '' && needs.check-early-exit.outputs.early_exit != 'true' }} # Only run if has bisection hash
     steps:
       - name: Add Bisect Label to New Issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.addLabels({
@@ -460,7 +460,7 @@ jobs:
             })
 
       - name: Link New Issue to Bisection Issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({
@@ -471,7 +471,7 @@ jobs:
             })
 
       - name: Link to Bisection Issue to New Issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -671,7 +671,7 @@ jobs:
       # Therefore will need toquery for issue comment id and then use that 
       # with peter-evans/create-or-update-comment.
       - name: Create or update summary issue
-        uses: JasonEtco/create-an-issue@v2
+        uses: JasonEtco/create-an-issue@v3
         id: create-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -671,7 +671,7 @@ jobs:
       # Therefore will need toquery for issue comment id and then use that 
       # with peter-evans/create-or-update-comment.
       - name: Create or update summary issue
-        uses: JasonEtco/create-an-issue@v3
+        uses: JasonEtco/create-an-issue@v2
         id: create-issue
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/init-submodules.yaml
+++ b/.github/workflows/init-submodules.yaml
@@ -36,7 +36,7 @@ jobs:
         working-directory: riscv-gnu-toolchain
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -45,7 +45,7 @@ jobs:
 
       - name: Retrieve cache
         id: retrieve-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             riscv-gnu-toolchain/.git
@@ -163,7 +163,7 @@ jobs:
       # Artifacts are reliable but ~30 min slower to set up.
       # Setup is done on one runner, so this isn't a show stopper.
       - name: Upload git cache
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}gcc-sources-${{ steps.gcc-hash.outputs.gcchash }}
           path: |

--- a/.github/workflows/init-submodules.yaml
+++ b/.github/workflows/init-submodules.yaml
@@ -142,7 +142,7 @@ jobs:
 
       - name: Cache submodules
         if: steps.retrieve-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         with:
           path: |
             riscv-gnu-toolchain/.git

--- a/.github/workflows/rvv-intrinsic-test.yaml
+++ b/.github/workflows/rvv-intrinsic-test.yaml
@@ -20,7 +20,7 @@ jobs:
           rm -rf ./.??* || true
           ls -la ./
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env
@@ -28,7 +28,7 @@ jobs:
           free_up_space: false
 
       - name: Restore submodules from cache
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: gcc-sources-${{ inputs.gcchash }}
           path: riscv-gnu-toolchain
@@ -92,7 +92,7 @@ jobs:
           zip -r rvv-intrinsic-testing-logs.zip logs
 
       - name: Upload logs artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: rvv-intrinsic-testing-logs
           path: |

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -34,7 +34,7 @@ jobs:
     environment: production
     if: ${{ inputs.gcchash == '' }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup env
         uses: ./.github/actions/common/setup-env


### PR DESCRIPTION
Fixes list of warning on runs. Changes done via find & replace-all 
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/