### PR TITLE
add missing prefix input for run testsuite in github runners

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -160,6 +160,7 @@ jobs:
           target: ${{ inputs.target }}
           gcchash: ${{ inputs.gcchash }}
           multilib: ${{ inputs.multilib }}
+          prefix: ${{ inputs.prefix }}
 
 
   # The self-hosted environment does not have the same path setup as the hosted runners
@@ -233,6 +234,7 @@ jobs:
           target: ${{ inputs.target }}
           gcchash: ${{ inputs.gcchash }}
           multilib: ${{ inputs.multilib }}
+          prefix: ${{ inputs.prefix }}
 
 
   # The self-hosted environment does not have the same path setup as the hosted runners


### PR DESCRIPTION
coordination branch failed to find testsuite results because they weren't being uploaded with the `coord_` prefix. 