### PR TITLE
Disable coordnation branch runners

### DIFF
--- a/.github/workflows/run-frequent-coordination.yaml
+++ b/.github/workflows/run-frequent-coordination.yaml
@@ -8,11 +8,11 @@ name: Run-Frequent-Coordination
 # There are 20 github runners, giving us a hard limit of 120 hrs every 6 hrs
 
 on:
-  schedule:
-    # Run 4 times a day
-    #- cron: 0 0,6,12,18 * * *
-    # Run once a day for now while we figure out the self-hosted runner issues
-    - cron: 0 0 * * *
+  # schedule:
+  #   # Run 4 times a day
+  #   #- cron: 0 0,6,12,18 * * *
+  #   # Run once a day for now while we figure out the self-hosted runner issues
+  #   - cron: 0 0 * * *
   workflow_call:
     inputs:
       gcchash:


### PR DESCRIPTION
Precommit does not know about coordnation branch runners. I think we should have a 'valid-baseline' label but until then turn it off. https://github.com/patrick-rivos/riscv-gnu-toolchain/blob/f6d0707d1ccb11411dcb634b09ba84cb7130388f/scripts/get_baseline_hash.py#L19