### PR TITLE
Parse new building warnings during generate summary workflow

### DIFF
--- a/.github/actions/common/unzip-all-zips/action.yaml
+++ b/.github/actions/common/unzip-all-zips/action.yaml
@@ -1,0 +1,37 @@
+name: "Unzip all zips"
+description: "Unzip all the zip files located in a given directory"
+inputs:
+  input-dir:
+    description: 'Directory that contains zip files'
+    required: true
+  output-dir:
+    description: 'Output directory that will contain all unzipped files'
+    required: true
+  include-pattern:
+    description: 'Remove all files that does not fit this pattern'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Output dir
+      id: create-output-dir
+      shell: bash
+      run: |
+        mkdir -p ${{ inputs.output-dir }}
+
+    - name: unzip all files
+      shell: bash
+      run: |
+        for zip_file in ${{ inputs.input-dir }}/*.zip; do
+          if [[ -e "$zip_file" ]]; then
+            unzip -o "$zip_file" -d ${{ inputs.output-dir }}
+          fi
+        done
+
+    - name: Filter Include Pattern
+      if: ${{ inputs.include-pattern }} != ''
+      shell: bash
+      run: |
+        find ${{ inputs.output-dir }} -type f ! -name "${{ inputs.include-pattern }}" -exec rm {} \;
+        ls ${{ inputs.output-dir }}

--- a/.github/actions/download-all-build-log-artifacts/action.yaml
+++ b/.github/actions/download-all-build-log-artifacts/action.yaml
@@ -3,12 +3,14 @@ description: "Downloads all the build log artifacts for a given hash. Only use t
 inputs:
   gcchash:
     required: true
+    description: 'GCC Hash of the artifact'
   github-token:
     required: true
   prefix:
     required: false
   output-dir:
     required: true
+    description: 'Path to the artifact directory'
 
 runs:
   using: "composite"
@@ -118,4 +120,5 @@ runs:
     - name: Print downloaded artifacts
       shell: bash
       run: |
-        ls riscv-gnu-toolchain/${{ inputs.output-dir }}
+        cd riscv-gnu-toolchain
+        ls ${{ inputs.output-dir }}

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -208,11 +208,66 @@ jobs:
           unzip ./temp/*report.log.zip -d ./current_logs || true
           ls current_logs
 
+      - name: Build Log Comparison Setup
+        id: build-log-setup
+        run: |
+          echo "previous_build_logs_path=$(readlink -f previous_build_logs)" >> $GITHUB_OUTPUT
+          echo "previous_build_log_zips_path=$(readlink -f previous_build_log_zips)" >> $GITHUB_OUTPUT
+          echo "current_build_logs_path=$(readlink -f current_build_logs)" >> $GITHUB_OUTPUT
+          echo "current_build_log_zips_path=$(readlink -f current_build_log_zips)" >> $GITHUB_OUTPUT
+          mkdir new_build_warnings
+          echo "new_build_warnings_path=$(readlink -f ./new_build_warnings/new_build_warnings.log)" >> $GITHUB_OUTPUT
+
       - name: Download artifacts
+        id: download-previous-artifacts
         run: |
           pip install pygithub requests
-          python ./scripts/download_artifacts.py -hash ${{ inputs.gcchash }} -repo patrick-rivos/gcc-postcommit-ci -token ${{ secrets.GITHUB_TOKEN }} -prefix "${{ inputs.prefix }}"
+          python ./scripts/download_artifacts.py -hash ${{ inputs.gcchash }} -repo patrick-rivos/gcc-postcommit-ci -token ${{ secrets.GITHUB_TOKEN }} -prefix "${{ inputs.prefix }}" -build-logs -build-logs-dir ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
           ls previous_logs
+          if [ -d "${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}" ]; then
+            ls ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
+          fi
+
+      - name: Unzip previous build log artifacts
+        id: unzip-previous-build-log-artifacts
+        uses: ./.github/actions/common/unzip-all-zips
+        with:
+          input-dir: ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
+          output-dir: ${{ steps.build-log-setup.outputs.previous_build_logs_path }}
+          include-pattern: "*-stderr.log"
+
+      - name: Download current build log artifacts manual
+        id: download-current-build-log-artifacts-manual
+        uses: ./.github/actions/download-all-build-log-artifacts
+        with:
+          gcchash: ${{ inputs.gcchash }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ inputs.prefix }}
+          output-dir: ${{ steps.build-log-setup.outputs.current_build_log_zips_path }}
+
+      - name: Unzip current build log artifacts
+        id: unzip-current-build-log-artifacts
+        uses: ./.github/actions/common/unzip-all-zips
+        with:
+          input-dir: ${{ steps.build-log-setup.outputs.current_build_log_zips_path }}
+          output-dir: ${{ steps.build-log-setup.outputs.current_build_logs_path }}
+          include-pattern: "*-stderr.log"
+
+      - name: Parse New Build Warnings
+        run: |
+          python ./scripts/parse_new_build_warnings.py --old-dir ${{ steps.build-log-setup.outputs.previous_build_logs_path }}/build --new-dir ${{ steps.build-log-setup.outputs.current_build_logs_path }}/build --output ${{ steps.build-log-setup.outputs.new_build_warnings_path }}
+          if [ -f "${{ steps.build-log-setup.outputs.new_build_warnings_path }}" ]; then
+            cat ${{ steps.build-log-setup.outputs.new_build_warnings_path }}
+          else
+            echo "New build logs didn't exist"
+          fi
+      
+      - name: Upload New Build Warnings
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.prefix }}${{ inputs.gcchash }}-build-warnings
+          path: ${{ steps.build-log-setup.outputs.new_build_warnings_path }}
+          retention-days: 90
 
       - name: Compare artifacts
         run: |


### PR DESCRIPTION
1. **New Action for Unzipping Files**
   - Created a new GitHub Action that unzips all zip files from a specified `input-dir` to a specified `output-dir`.
   - Users can specify an `include-pattern` to retain only files matching the pattern; other files will be deleted. If not specified, all unzipped files remain.

2. **Integrated Warning Parsing Script**
   - Integrated `parse_new_build_warnings.py` into the `generate_summary` workflow.
   - `download_artifacts.py` downloads previous build logs using the same base hash as the report log. Results are displayed in the steps, with potential future integration into issue comments if stable.
   - [Successful Run Example](https://github.com/patrick-rivos/gcc-postcommit-ci/actions/runs/9651738581/job/26620308889#step:22:122)