### PR TITLE
Add a new action that downloads all the build log

### DIFF
--- a/.github/actions/download-all-build-log-artifacts/action.yaml
+++ b/.github/actions/download-all-build-log-artifacts/action.yaml
@@ -1,0 +1,121 @@
+name: "Download All Buid Log Artifacts"
+description: "Downloads all the build log artifacts for a given hash. Only use this action if the given gcchash is not built in the current run"
+inputs:
+  gcchash:
+    required: true
+  github-token:
+    required: true
+  prefix:
+    required: false
+  output-dir:
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    # Download linux
+
+    - name: Download linux rv32 non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        pip install pygithub requests
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}linux-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download linux rv64gc non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+    
+    - name: Download linux rv32 bitmanip non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download linux rv64 bitmanip non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    # Newlib
+
+    - name: Download newlib rv32 non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}newlib-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download newlib rv64gc non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download newlib rv32 bitmanip non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}newlib-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download newlib rv64 bitmanip non-multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    # Multilib
+    - name: Download linux multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}linux-rv64gcv-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download newlib multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}linux-newlib-rv64gcv-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download newlib uc multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}newlib-rv64imc-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Download newlib uc bitmanip multilib
+      shell: bash
+      continue-on-error: true
+      run: |
+        cd riscv-gnu-toolchain
+        build_artifact_name=${{ inputs.prefix }}newlib-rv64imc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+
+    - name: Print downloaded artifacts
+      shell: bash
+      run: |
+        ls riscv-gnu-toolchain/${{ inputs.output-dir }}


### PR DESCRIPTION
New action mimics download-all-comparison artifacts action. It searches for all the build artifact for a given gcchash then download it to the output-dir using download_artifact.py script. This includes all the target-hash-multilib combination. 

[Test Workflow result](https://github.com/patrick-rivos/gcc-postcommit-ci/actions/runs/9702074991/job/26777087822#step:6:800)