### PR TITLE
fix incorrect bash statement

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -76,7 +76,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/patrick-rivos/gcc-postcommit-ci/issues \
             -o issues.txt
-          FOUND_ISSUE=$(cat issues.txt | jq 'map(select(.title == "$ISSUE_NAME"))')
+          FOUND_ISSUE=$(cat issues.txt | jq "map(select(.title == \"$ISSUE_NAME\"))")
           # if no issue of that name is found, jq returns '[]'
           echo "found_issue=$FOUND_ISSUE" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Bash wasn't properly expanding environment variables due to using `''` instead of `""`
Therefore, `'map(select(.title == "$ISSUE_NAME"))')` resulted in `map(select(.title == "$ISSUE_NAME"))` instead of `map(select(.title == "Testsuite Status <HASH>"))` which always led to `jq` returning `[]`