### PR TITLE
Change newlines to spaces for github output

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -76,7 +76,7 @@ jobs:
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/patrick-rivos/gcc-postcommit-ci/issues \
             -o issues.txt
-          FOUND_ISSUE=$(cat issues.txt | jq "map(select(.title == \"$ISSUE_NAME\"))")
+          FOUND_ISSUE=$(cat issues.txt | jq "map(select(.title == \"$ISSUE_NAME\"))" | tr '\n' ' ')
           # if no issue of that name is found, jq returns '[]'
           echo "found_issue=$FOUND_ISSUE" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Apparently `GITHUB_OUTPUT` doesn't allow multiline variable values https://github.com/patrick-rivos/gcc-postcommit-ci/actions/runs/9705671094/job/26801600756#step:4:107. Convert newlines to spaces

Tested in my action sandbox: https://github.com/ewlu/action_testing/actions/runs/9716064426/job/26818837271#step:3:106
