### PR TITLE
Fix parse new build warnings

### DIFF
--- a/.github/actions/common/download-build-log-artifact/action.yaml
+++ b/.github/actions/common/download-build-log-artifact/action.yaml
@@ -1,0 +1,34 @@
+name: "Download Build Artifacts"
+description: "Downloads artifacts needed for build log comparison"
+inputs:
+  build-artifact-name:
+    required: true
+  github-token:
+    required: true
+  output-dir:
+    required: true
+    description: 'Absolute path to the output directory'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Download report from this workflow
+      if: ${{ !cancelled() }}
+      id: same-workflow
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.build-artifact-name }}
+        path: ${{ inputs.output-dir }}
+      continue-on-error: true
+
+    # If an artifact from the same workflow is not found, the conclusion
+    # will be success but the outcome will be failure. 
+    # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+    - name: Download report from another workflow
+      if: ${{ !cancelled() && steps.same-workflow.outcome == 'failure' }}
+      shell: bash
+      run: |
+        pip install pygithub requests
+        cd riscv-gnu-toolchain
+        python ./scripts/download_artifact.py -name ${{ inputs.build-artifact-name }} -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      continue-on-error: true

--- a/.github/actions/download-all-build-log-artifacts/action.yaml
+++ b/.github/actions/download-all-build-log-artifacts/action.yaml
@@ -10,112 +10,103 @@ inputs:
     required: false
   output-dir:
     required: true
-    description: 'Path to the artifact directory'
+    description: 'Absolute Path to the artifact directory'
 
 runs:
   using: "composite"
   steps:
-    # Download linux
-
-    - name: Download linux rv32 non-multilib
+    - name: prereqs
       shell: bash
-      continue-on-error: true
       run: |
-        pip install pygithub requests
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}linux-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+        mkdir -p ${{ inputs.output-dir }}
+
+    # Download linux
+    - name: Download linux rv32 non-multilib
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}linux-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download linux rv64gc non-multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
-    
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}linux-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
+
     - name: Download linux rv32 bitmanip non-multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}linux-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download linux rv64 bitmanip non-multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}linux-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     # Newlib
 
     - name: Download newlib rv32 non-multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}newlib-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}newlib-rv32gc-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download newlib rv64gc non-multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}newlib-rv64gc-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download newlib rv32 bitmanip non-multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}newlib-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}newlib-rv32gc_zba_zbb_zbc_zbs-ilp32d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download newlib rv64 bitmanip non-multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}newlib-rv64gc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-non-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     # Multilib
     - name: Download linux multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}linux-rv64gcv-lp64d-${{ inputs.gcchash }}-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}linux-rv64gcv-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download newlib multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}linux-newlib-rv64gcv-lp64d-${{ inputs.gcchash }}-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}newlib-rv64gcv-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download newlib uc multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}newlib-rv64imc-lp64d-${{ inputs.gcchash }}-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}newlib-rv64imc-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Download newlib uc bitmanip multilib
-      shell: bash
-      continue-on-error: true
-      run: |
-        cd riscv-gnu-toolchain
-        build_artifact_name=${{ inputs.prefix }}newlib-rv64imc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-multilib-build-log
-        python ./scripts/download_artifact.py -name $build_artifact_name -repo patrick-rivos/gcc-postcommit-ci -token ${{ inputs.github-token }} -outdir ${{ inputs.output-dir }}
+      uses: ./.github/actions/common/download-build-log-artifact
+      with:
+        build-artifact-name: ${{ inputs.prefix }}newlib-rv64imc_zba_zbb_zbc_zbs-lp64d-${{ inputs.gcchash }}-multilib-build-log
+        github-token: ${{ inputs.github-token }}
+        output-dir: ${{ inputs.output-dir }}
 
     - name: Print downloaded artifacts
       shell: bash

--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -224,11 +224,66 @@ jobs:
           unzip ./temp/*report.log.zip -d ./current_logs || true
           ls current_logs
 
+      - name: Build Log Comparison Setup
+        id: build-log-setup
+        run: |
+          mkdir -p previous_build_logs
+          echo "previous_build_logs_path=$(readlink -f previous_build_logs)" >> $GITHUB_OUTPUT
+          mkdir -p previous_build_log_zips
+          echo "previous_build_log_zips_path=$(readlink -f previous_build_log_zips)" >> $GITHUB_OUTPUT
+          mkdir -p current_build_logs
+          echo "current_build_logs_path=$(readlink -f current_build_logs)" >> $GITHUB_OUTPUT
+          mkdir -p current_build_log_zips
+          echo "current_build_log_zips_path=$(readlink -f current_build_log_zips)" >> $GITHUB_OUTPUT
+          mkdir new_build_warnings
+          echo "new_build_warnings_path=$(readlink -f ./new_build_warnings/new_build_warnings.log)" >> $GITHUB_OUTPUT
+
       - name: Download artifacts
         run: |
           pip install pygithub requests
-          python ./scripts/download_artifacts.py -hash ${{ inputs.gcchash }} -repo patrick-rivos/gcc-postcommit-ci -token ${{ secrets.GITHUB_TOKEN }} -prefix "${{ inputs.prefix }}"
+          python ./scripts/download_artifacts.py -hash ${{ inputs.gcchash }} -repo patrick-rivos/gcc-postcommit-ci -token ${{ secrets.GITHUB_TOKEN }} -prefix "${{ inputs.prefix }}" -build-logs -build-logs-dir ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
           ls previous_logs
+          if [ -d "${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}" ]; then
+            ls ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
+          fi
+
+      - name: Unzip previous build log artifacts
+        uses: ./.github/actions/common/unzip-all-zips
+        with:
+          input-dir: ${{ steps.build-log-setup.outputs.previous_build_log_zips_path }}
+          output-dir: ${{ steps.build-log-setup.outputs.previous_build_logs_path }}
+          include-pattern: "*-stderr.log"
+
+      - name: Download current build log artifacts
+        uses: ./.github/actions/download-all-build-log-artifacts
+        with:
+          gcchash: ${{ inputs.gcchash }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          prefix: ${{ inputs.prefix }}
+          output-dir: ${{ steps.build-log-setup.outputs.current_build_log_zips_path }}
+
+      - name: Unzip current build log artifacts
+        uses: ./.github/actions/common/unzip-all-zips
+        with:
+          input-dir: ${{ steps.build-log-setup.outputs.current_build_log_zips_path }}
+          output-dir: ${{ steps.build-log-setup.outputs.current_build_logs_path }}
+          include-pattern: "*-stderr.log"
+
+      - name: Parse New Build Warnings
+        run: |
+          python ./scripts/parse_new_build_warnings.py --old-dir ${{ steps.build-log-setup.outputs.previous_build_logs_path }}/build --new-dir ${{ steps.build-log-setup.outputs.current_build_logs_path }}/build --output ${{ steps.build-log-setup.outputs.new_build_warnings_path }} --repo post-commit
+          if [ -f "${{ steps.build-log-setup.outputs.new_build_warnings_path }}" ]; then
+            cat ${{ steps.build-log-setup.outputs.new_build_warnings_path }}
+          else
+            echo "New build logs didn't exist"
+          fi
+
+      - name: Upload New Build Warnings
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.prefix }}${{ inputs.gcchash }}-build-warnings
+          path: ${{ steps.build-log-setup.outputs.new_build_warnings_path }}
+          retention-days: 90
 
       - name: Compare artifacts
         run: |


### PR DESCRIPTION
Modify the download-all-build-artifacts action to replicate download-all-comparison-artifacts to search both the current workflow and other workflows for a specified artifact.

Moreover, revert the reverted use of parse new build warnings script.