### PR TITLE
add links to end of comments for easier navigation

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -415,13 +415,25 @@ jobs:
           title: '${{ inputs.issue_hash_prefix }} ${{ inputs.gcchash }}'
           labels: ${{ steps.issue-labels.outputs.issue_labels }}
 
+      - name: Build additional info link
+        id: issue-info
+        run: |
+          sleep 1
+          curl -L -H "Accept: application/vnd.github+json" -H "Authorization: Token ${{ secrets.GITHUB_TOKEN }}" -H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/patrick-rivos/gcc-postcommit-ci/issues/${{ steps.create-issue.outputs.issue-number }} | jq '.id' > issue_body_comment_id.txt
+          export ISSUE_BODY_COMMENT=$(cat issue_body_comment_id.txt)
+          export LINK=https://github.com/patrick-rivos/gcc-postcommit-ci/issues/${{ steps.create-issue.outputs.issue-number }}#issue-$(cat issue_body_comment_id.txt)
+          echo $LINK
+          echo "additional=$LINK" >> $GITHUB_OUTPUT
+          echo "comment_id=$ISSUE_BODY_COMMENT" >> $GITHUB_OUTPUT
+
       - name: Trim comment length # reduce the number of lines in final comment so github always create comment
         run: |
           printf "## Important unresolved errors\n" > trimmed_comment.md
           printf 'A list of all unresolved "internal compiler error", "Segmentation fault", "test for excess errors" failures present at this hash\n\n' >> trimmed_comment.md
           printf -- '---\n\n' >> trimmed_comment.md
           head -c 65000 unresolved_important_failures.md >> trimmed_comment.md
-          if [ $(cat trimmed_comment.md | wc -l) -ne $(cat unresolved_important_failures.md | wc -l) ]; then printf "\n\`\`\`\nComment text has been trimmed. Check artifact logs for full list.\n" >> trimmed_comment.md; fi
+          if [ $(cat trimmed_comment.md | wc -l) -ne $(cat unresolved_important_failures.md | wc -l) ]; then printf "\nComment text has been trimmed. Check artifact logs for full list.\n" >> trimmed_comment.md; fi
+          printf "\n[Additional information](${{ steps.issue-info.outputs.additional }})\n" >> trimmed_comment.md
           cat trimmed_comment.md
 
       - name: Create unresolved regressions comment
@@ -431,6 +443,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           issue-number: ${{ steps.create-issue.outputs.issue-number }}
+          body-path: riscv-gnu-toolchain/trimmed_comment.md
+
+      - name: Create updated issue body
+        run: |
+          printf "\n[Unresolved comments](https://github.com/patrick-rivos/gcc-postcommit-ci/issues/${{ steps.create-issue.outputs.issue-number }}#issue-${{ steps.unresolved-comment.outputs.comment-id }})" >> trimmed_issue.md
+          cat trimmed_issue.md
+
+      - name: Update original issue body
+        uses: peter-evans/create-or-update-comment@v4
+        id: update-issue
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          edit-mode: replace
+          comment-id: ${{ steps.issue-info.outputs.comment_id }}
           body-path: riscv-gnu-toolchain/trimmed_comment.md
 
       - name: Get prefix label name


### PR DESCRIPTION
would be like precommit where each comment would have a link which takes back to original issue body. At the end of the issue body, there will be links to the other comments that were created by ci to make jumping around the issue sections easier.