### PR TITLE
Build warnings artifact download quick fix

### DIFF
--- a/.github/workflows/generate-summary.yaml
+++ b/.github/workflows/generate-summary.yaml
@@ -362,7 +362,7 @@ jobs:
         with:
           name: ${{ inputs.prefix }}${{ inputs.gcchash }}-build-warnings
           path: ./riscv-gnu-toolchain
-          continue-on-error: true
+        continue-on-error: true
 
       - name: Print API usage info
         run: |


### PR DESCRIPTION
Continue-on-error was accidentally part of the action's with parameter. 

Fix this to properly skip when error occurs.