### PR TITLE
Add flakey gfortran/sizeof_6.f90 to allowlist

### DIFF
--- a/test/allowlist/gcc/glibc.rv64.zbs.log
+++ b/test/allowlist/gcc/glibc.rv64.zbs.log
@@ -1,0 +1,4 @@
+#
+# Timeout: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=116261
+#
+FAIL: gfortran.dg/sizeof_6.f90 -O1 execution test


### PR DESCRIPTION
Add to bitmanip allowlist. When `sizeof_6.f90` is fixed for rv64 linux vector targets, this should also be fixed.