### PR TITLE
Build log Artifact upload condition change

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -62,14 +62,14 @@ runs:
           set +o pipefail
 
       - name: Zip build log
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         shell: bash
         working-directory: riscv-gnu-toolchain
         run: |
           zip ${{ inputs.build_log_name }}.zip build/${{ inputs.build_log_name }}.log build/${{ inputs.build_log_name }}-stdout.log build/${{ inputs.build_log_name }}-stderr.log
 
       - name: Upload build log
-        if: ${{ always() }}
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.prefix }}${{ inputs.build_log_name }}


### PR DESCRIPTION
Previously, the condition was `always()` which uploaded the build log even if the run is cancelled. This caused a corrupted override in the build log.

By using `!cancelled()`, it allows the upload in all the other conditions except for when the run is cancelled.