### PR TITLE
Build Log Concurrency Fix

### DIFF
--- a/.github/actions/common/build-target/action.yaml
+++ b/.github/actions/common/build-target/action.yaml
@@ -58,7 +58,7 @@ runs:
         run: |
           cd build
           set -o pipefail
-          (make -j20 ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
+          (make -j20 --output-sync=target ${{ inputs.mode }}) 2> >(tee ${{ inputs.build_log_name }}-stderr.log) > >(tee ${{ inputs.build_log_name }}-stdout.log) | tee ${{ inputs.build_log_name }}.log
           set +o pipefail
 
       - name: Zip build log

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -225,7 +225,7 @@ jobs:
       - name: Build
         run: |
           cd build
-          make ${{ inputs.mode }} -j20
+          make ${{ inputs.mode }} -j20 --output-sync=target
 
       - name: Run Testsuite
         uses: ./.github/actions/common/run-testsuite

--- a/.github/workflows/build-with-checking.yaml
+++ b/.github/workflows/build-with-checking.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Make gcc
         run: |
           cd build
-          make -j $(nproc) ${{ inputs.mode }}
+          make -j $(nproc) ${{ inputs.mode }}  --output-sync=target
 
       - name: Remove sources to reclaim disk space
         run: |


### PR DESCRIPTION
Build warnings were parsed incorrectly due to different warnings overwritting each other. Use make's native `output-sync` option to resolve concurrent logging issue. 

`--output-sync=target` guarantees that the logs are written only if the target is done and different jobs writes the log sequentially.