### PR TITLE
bump binutils gcc version

### DIFF
--- a/.github/workflows/run-daily-rv-gc-binutils.yaml
+++ b/.github/workflows/run-daily-rv-gc-binutils.yaml
@@ -20,7 +20,7 @@ jobs:
       # Add new prefixes to /dashboard/getdata.py in download_summaries()
       # ^ Ignored for now since we're testing binutils
       prefix: 'binutils_'
-      gcchash: 'cd0059a1976303638cea95f216de129334fc04d1' # Arbitrary fixed GCC hash
+      gcchash: '04696df09633baf97cdbbdd6e9929b9d472161d3' # Arbitrary fixed GCC hash
       gcc_branch: master
       binutils_branch: master
 


### PR DESCRIPTION
since we bumped the self-hosted/github runners to 24.04, our binutils runner has been getting stack overflow issues. The issue appears to be from using gcc 14.1.0. Bump to use gcc 14.2.0 as the gcc hash we test against https://github.com/patrick-rivos/gcc-postcommit-ci/issues/2803