### PR TITLE
remove required hash to automatically test tip of tree

### DIFF
--- a/.github/workflows/run-frequent.yaml
+++ b/.github/workflows/run-frequent.yaml
@@ -27,7 +27,7 @@ on:
     inputs:
       gcchash:
         description: 'GCC Hash'
-        required: true
+        required: false
       multi_target:
         description: 'Targets to run (libc:arch-abi;...)'
         required: false


### PR DESCRIPTION
makes it easier to kick off a new run on tip of tree instead of needing to manually input the tip of tree hash