### PR TITLE
update release-14 branch

### DIFF
--- a/.github/actions/common/init-and-pull-gcc/action.yaml
+++ b/.github/actions/common/init-and-pull-gcc/action.yaml
@@ -93,7 +93,7 @@ runs:
         run: |
           cd gcc
           git fetch
-          git checkout releases/gcc-14
+          git checkout origin/releases/gcc-14
         continue-on-error: true
 
       - name: Sleep and retry
@@ -105,4 +105,4 @@ runs:
           sleep 60
           cd gcc
           git fetch
-          git checkout releases/gcc-14
+          git checkout origin/releases/gcc-14


### PR DESCRIPTION
Looking at the releases/gcc-14 branch, there have been more commits that have occurred which haven't been properly tested. For example, the latest release-14 hash we tested was 3a07660a5a6a4f09e6e9478229e7609697a9105e which is the daily bump commit from 3/12/2025. Pull from origin/releases/gcc-14 instead of just releases/gcc-14