### PR TITLE
remove required gcc hash on workflow_dispatch

### DIFF
--- a/.github/workflows/run-frequent-14.yaml
+++ b/.github/workflows/run-frequent-14.yaml
@@ -22,7 +22,7 @@ on:
     inputs:
       gcchash:
         description: 'GCC Hash'
-        required: true
+        required: false
       multi_target:
         description: 'Targets to run (libc:arch-abi;...)'
         required: false

--- a/.github/workflows/run-frequent-15.yaml
+++ b/.github/workflows/run-frequent-15.yaml
@@ -22,7 +22,7 @@ on:
     inputs:
       gcchash:
         description: 'GCC Hash'
-        required: true
+        required: false
       multi_target:
         description: 'Targets to run (libc:arch-abi;...)'
         required: false

--- a/.github/workflows/run-frequent-coordination.yaml
+++ b/.github/workflows/run-frequent-coordination.yaml
@@ -22,7 +22,7 @@ on:
     inputs:
       gcchash:
         description: 'GCC Hash'
-        required: true
+        required: false
       multi_target:
         description: 'Targets to run (libc:arch-abi;...)'
         required: false

--- a/.github/workflows/staging.yaml
+++ b/.github/workflows/staging.yaml
@@ -14,7 +14,7 @@ on:
     inputs:
       gcchash:
         description: 'GCC Hash'
-        required: true
+        required: false
       issue_num:
         description: 'Bisection Issue Number (Optional)'
         required: false


### PR DESCRIPTION
the init and pull gcc action should cover cases with/without passing gcchash in workflow dispatch