### PR TITLE
Allowlist flakey test

### DIFF
--- a/test/allowlist/gcc/glibc.log
+++ b/test/allowlist/gcc/glibc.log
@@ -25,3 +25,8 @@ FAIL: gcc.dg/vect/tsvc/vect-tsvc-s176.c
 FAIL: gcc.dg/vect/tsvc/vect-tsvc-s351.c
 FAIL: gcc.dg/vect/tsvc/vect-tsvc-s431.c
 FAIL: gcc.dg/vect/tsvc/vect-tsvc-s1281.c
+
+#
+# TODO: Root cause & file bugzilla
+#
+FAIL: gcc.misc-tests/gcov-pr86536.c 


### PR DESCRIPTION
Looks like this has been flakey for about a month https://github.com/patrick-rivos/gcc-postcommit-ci/issues/4713

precommit unaffected since it seems like it's only been seen under the "resolved regressions" label and therefore not causing false failures upstream